### PR TITLE
fix: correct directory name in setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A production-grade text analysis tool built with enterprise-level architecture, 
 ```bash
 # Clone the repository
 git clone <your-repo-url>
-cd text-analyzer
+cd Text-Analyzer
 
 # Make scripts executable (Required for all platforms)
 chmod +x scripts/setup-*.sh


### PR DESCRIPTION
## Fix: Setup Instructions Directory Name

**Summary**  
Fixed directory name in README setup instructions to match repository name.

**Change**
- Updated `cd text-analyzer` to `cd Text-Analyzer` to match actual cloned folder name
